### PR TITLE
fixed create post modal closing on request not fulfilled

### DIFF
--- a/src/components/modals/CreatePostModal.tsx
+++ b/src/components/modals/CreatePostModal.tsx
@@ -56,7 +56,6 @@ export const CreatePostModal = () => {
         duration: 9000,
         isClosable: true,
       });
-      dispatch(closeCreatePostModal());
       
     }
   }, [post, isError, isSuccess, message, dispatch, toast]);
@@ -83,7 +82,11 @@ export const CreatePostModal = () => {
       });
     }
     dispatch(createPost(formData));
-    
+    if(title.length !== 0 && description.length !== 0){
+      isSuccess && dispatch(closeCreatePostModal());
+    }
+
+    return;
   };
 
   return (


### PR DESCRIPTION
Before if you open create-post-modal and click the "create post" button without filling in the form, the modal would close